### PR TITLE
Fix :python and :python3 deprection

### DIFF
--- a/vtk5.rb
+++ b/vtk5.rb
@@ -55,7 +55,7 @@ class Vtk5 < Formula
 
   depends_on "cmake" => :build
   depends_on "patmarion/director/qt" => :recommended
-  depends_on :python => :recommended
+  depends_on "python" => :recommended
   depends_on "hdf5" => :recommended
   depends_on "jpeg" => :recommended
   depends_on "libpng" => :recommended

--- a/vtk7.rb
+++ b/vtk7.rb
@@ -37,8 +37,8 @@ class Vtk7 < Formula
   depends_on :x11 => :optional
   depends_on "patmarion/director/qt" => :recommended
 
-  depends_on :python => :recommended
-  depends_on :python3 => :optional
+  depends_on "python" => :recommended
+  depends_on "python3" => :optional
 
   depends_on "boost" => :optional
   depends_on "fontconfig" => :recommended

--- a/vtk7python3.rb
+++ b/vtk7python3.rb
@@ -37,8 +37,8 @@ class Vtk7python3 < Formula
   depends_on :x11 => :optional
   depends_on "patmarion/director/qt" => :recommended
 
-  depends_on :python => :optional
-  depends_on :python3 => :recommended
+  depends_on "python" => :optional
+  depends_on "python3" => :recommended
 
   depends_on "boost" => :optional
   depends_on "fontconfig" => :recommended


### PR DESCRIPTION
This fixes the following warnings:

```
Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/patmarion/homebrew-director/vtk5.rb:58:in `<class:Vtk5>'
Please report this to the patmarion/director tap!

Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/patmarion/homebrew-director/vtk7.rb:40:in `<class:Vtk7>'
Please report this to the patmarion/director tap!

Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python3"' instead.
/usr/local/Homebrew/Library/Taps/patmarion/homebrew-director/vtk7.rb:41:in `<class:Vtk7>'
Please report this to the patmarion/director tap!

Warning: Calling 'depends_on :python' is deprecated!
Use 'depends_on "python"' instead.
/usr/local/Homebrew/Library/Taps/patmarion/homebrew-director/vtk7python3.rb:40:in `<class:Vtk7python3>'
Please report this to the patmarion/director tap!

Warning: Calling 'depends_on :python3' is deprecated!
Use 'depends_on "python3"' instead.
/usr/local/Homebrew/Library/Taps/patmarion/homebrew-director/vtk7python3.rb:41:in `<class:Vtk7python3>'
Please report this to the patmarion/director tap!
```